### PR TITLE
Advanced options in object instead of window manager

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -83,28 +83,34 @@ def generate_rig(context, metarig):
 
     rig_new_name = ""
     rig_old_name = ""
-    if id_store.rigify_rig_basename:
-        rig_new_name = id_store.rigify_rig_basename + "_rig"
-
-    if id_store.rigify_generate_mode == 'overwrite':
-        name = id_store.rigify_target_rig or "rig"
-        try:
-            obj = scene.objects[name]
-            rig_old_name = name
-            obj.name = rig_new_name or name
-        except KeyError:
-            rig_old_name = name
-            name = rig_new_name or name
-            obj = bpy.data.objects.new(name, bpy.data.armatures.new(name))
-            obj.draw_type = 'WIRE'
-            scene.objects.link(obj)
+    if metarig.data.rigify_rig_basename:
+        rig_new_name = metarig.data.rigify_rig_basename + "_rig"
     else:
-        name = rig_new_name or "rig"
-        obj = bpy.data.objects.new(name, bpy.data.armatures.new(name))  # in case name 'rig' exists it will be rig.001
+        rig_new_name = "rig"
+
+    if metarig.data.rigify_generate_mode == 'overwrite':
+        if metarig.data.rigify_target_rig is not None:
+            rig_old_name = metarig.data.rigify_target_rig.name
+            obj = metarig.data.rigify_target_rig
+            obj.name = rig_new_name or obj.name
+        else:
+            name = rig_new_name
+            if name in bpy.data.objects:
+                obj = bpy.data.objects[name]
+            else:
+                obj = bpy.data.objects.new(name, bpy.data.armatures.new(name))
+                obj.draw_type = 'WIRE'
+                scene.objects.link(obj)
+    else:
+        name = rig_new_name
+        obj = bpy.data.objects.new(name, bpy.data.armatures.new(name))
         obj.draw_type = 'WIRE'
         scene.objects.link(obj)
 
-    id_store.rigify_target_rig = obj.name
+    if obj.name not in bpy.context.scene.objects:  # rig exists but deleted
+        bpy.context.scene.objects.link(obj)
+
+    metarig.data.rigify_target_rig = obj
     obj.data.pose_position = 'POSE'
 
     # Get rid of anim data in case the rig already existed
@@ -118,8 +124,7 @@ def generate_rig(context, metarig):
 
     # Remove wgts if force update is set
     wgts_group_name = "WGTS_" + (rig_old_name or obj.name)
-    if wgts_group_name in scene.objects and id_store.rigify_force_widget_update:
-        bpy.ops.object.mode_set(mode='OBJECT')
+    if wgts_group_name in scene.objects and metarig.data.rigify_force_widget_update:
         bpy.ops.object.select_all(action='DESELECT')
         for i, lyr in enumerate(WGT_LAYERS):
             if lyr:
@@ -477,23 +482,25 @@ def generate_rig(context, metarig):
         layer_layout += [(l.name, l.row)]
 
     # Generate the UI script
-    if id_store.rigify_generate_mode == 'overwrite':
-        rig_ui_name = id_store.rigify_rig_ui or 'rig_ui.py'
+    if metarig.data.rigify_rig_basename:
+        script_name = metarig.data.rigify_rig_basename + "_rig_ui.py"
     else:
-        rig_ui_name = 'rig_ui.py'
+        script_name = "rig_ui.py"
 
-    if id_store.rigify_generate_mode == 'overwrite' and rig_ui_name in bpy.data.texts.keys():
-        script = bpy.data.texts[rig_ui_name]
-        script.clear()
+    if metarig.data.rigify_generate_mode == 'overwrite':
+        if metarig.data.rigify_rig_ui:
+            script = metarig.data.rigify_rig_ui
+        else:
+            if script_name in bpy.data.texts:
+                script = bpy.data.texts[script_name]
+            else:
+                script = bpy.data.texts.new(script_name)
     else:
         script = bpy.data.texts.new("rig_ui.py")
 
-    rig_ui_old_name = ""
-    if id_store.rigify_rig_basename:
-        rig_ui_old_name = script.name
-        script.name = id_store.rigify_rig_basename + "_rig_ui.py"
+    script.name = script_name
 
-    id_store.rigify_rig_ui = script.name
+    metarig.data.rigify_rig_ui = script
 
     script.write(UI_SLIDERS % rig_id)
     for s in ui_scripts:

--- a/ui.py
+++ b/ui.py
@@ -93,10 +93,12 @@ class DATA_PT_rigify_buttons(bpy.types.Panel):
                 layout.operator("pose.rigify_upgrade_types", text="Upgrade Metarig")
 
             row = layout.row()
+            armature_id_store = C.object.data
+
             row.operator("pose.rigify_generate", text="Generate Rig", icon='POSE_HLT')
             row.enabled = enable_generate_and_advanced
 
-            if id_store.rigify_advanced_generation:
+            if armature_id_store.rigify_advanced_generation:
                 icon = 'UNLOCKED'
             else:
                 icon = 'LOCKED'
@@ -104,12 +106,12 @@ class DATA_PT_rigify_buttons(bpy.types.Panel):
             col = layout.column()
             col.enabled = enable_generate_and_advanced
             row = col.row()
-            row.prop(id_store, "rigify_advanced_generation", toggle=True, icon=icon)
+            row.prop(armature_id_store, "rigify_advanced_generation", toggle=True, icon=icon)
 
-            if id_store.rigify_advanced_generation:
+            if armature_id_store.rigify_advanced_generation:
 
                 row = col.row(align=True)
-                row.prop(id_store, "rigify_generate_mode", expand=True)
+                row.prop(armature_id_store, "rigify_generate_mode", expand=True)
 
                 main_row = col.row(align=True).split(percentage=0.3)
                 col1 = main_row.column()
@@ -117,41 +119,26 @@ class DATA_PT_rigify_buttons(bpy.types.Panel):
                 col1.label(text="Rig Name")
                 row = col1.row()
                 row.label(text="Target Rig")
-                row.enabled = (id_store.rigify_generate_mode == "overwrite")
+                row.enabled = (armature_id_store.rigify_generate_mode == "overwrite")
                 row = col1.row()
                 row.label(text="Target UI")
-                row.enabled = (id_store.rigify_generate_mode == "overwrite")
+                row.enabled = (armature_id_store.rigify_generate_mode == "overwrite")
 
                 row = col2.row(align=True)
-                row.prop(id_store, "rigify_rig_basename", text="", icon="SORTALPHA")
+                row.prop(armature_id_store, "rigify_rig_basename", text="", icon="SORTALPHA")
 
                 row = col2.row(align=True)
-                for i in range(0, len(id_store.rigify_target_rigs)):
-                    id_store.rigify_target_rigs.remove(0)
+                row.prop(armature_id_store, "rigify_target_rig", text="")
+                row.enabled = (armature_id_store.rigify_generate_mode == "overwrite")
 
-                for ob in context.scene.objects:
-                    if type(ob.data) == bpy.types.Armature and "rig_id" in ob.data:
-                        id_store.rigify_target_rigs.add()
-                        id_store.rigify_target_rigs[-1].name = ob.name
-
-                row.prop_search(id_store, "rigify_target_rig", id_store, "rigify_target_rigs", text="",
-                                icon='OUTLINER_OB_ARMATURE')
-                row.enabled = (id_store.rigify_generate_mode == "overwrite")
-
-                for i in range(0, len(id_store.rigify_rig_uis)):
-                    id_store.rigify_rig_uis.remove(0)
-
-                for t in bpy.data.texts:
-                    id_store.rigify_rig_uis.add()
-                    id_store.rigify_rig_uis[-1].name = t.name
 
                 row = col2.row()
-                row.prop_search(id_store, "rigify_rig_ui", id_store, "rigify_rig_uis", text="", icon='TEXT')
-                row.enabled = (id_store.rigify_generate_mode == "overwrite")
+                row.prop(armature_id_store, "rigify_rig_ui", text="")
+                row.enabled = (armature_id_store.rigify_generate_mode == "overwrite")
 
                 row = col.row()
-                row.prop(id_store, "rigify_force_widget_update")
-                if id_store.rigify_generate_mode == 'new':
+                row.prop(armature_id_store, "rigify_force_widget_update")
+                if armature_id_store.rigify_generate_mode == 'new':
                     row.enabled = False
 
         elif obj.mode == 'EDIT':
@@ -1417,4 +1404,3 @@ def unregister():
     bpy.utils.unregister_class(OBJECT_OT_Rot2Pole)
 
     rot_mode.unregister()
-


### PR DESCRIPTION
I changed the place where the Advanced Options are stored, from the window manager to the Object datablock. The advantage is twofold:
* Having several metarigs not share properties in the same blend file, thus generating to different rigs, not overwriting by mistake, etc.
* Saving this data to file, which is not the case with wm data. This avoids mistakes with named rigs not being replaced.

Please note that this uses [Blender 2.79's new PointerProperties](https://wiki.blender.org/index.php/Dev:Ref/Release_Notes/2.79/PythonAPI#Forward_Compatibility), so it is as stated not compatible with previous versions, and will furthermore make blend files impossible to open in previous versions.

I have got one question: why add *_rig* after the name? I should be able to name my rig anything, right? I left it that way for now.