### PR TITLE
Utilities for creating the rig mechanism (constraints, drivers)

### DIFF
--- a/rigs/spines/super_spine.py
+++ b/rigs/spines/super_spine.py
@@ -6,6 +6,7 @@ from ...utils import create_circle_widget, create_sphere_widget, create_neck_ben
 from ..widgets import create_ballsocket_widget
 from ...utils import MetarigError, make_mechanism_name, create_cube_widget
 from ...utils import ControlLayersOption
+from ...utils.mechanism import MechanismUtilityMixin
 from rna_prop_ui import rna_idprop_ui_prop_get
 
 script = """
@@ -22,7 +23,7 @@ if is_selected( controls ):
 """
 
 
-class Rig:
+class Rig(MechanismUtilityMixin):
 
     def __init__(self, obj, bone_name, params):
         """ Initialize torso rig and key rig properties """
@@ -558,44 +559,35 @@ class Rig:
         if self.use_head:
             eb[org_bones[-1]].parent = eb[bones['neck']['ctrl']]
 
-    def make_constraint(self, bone, constraint):
+    def constrain_bones(self, bones):
         bpy.ops.object.mode_set(mode='OBJECT')
         pb = self.obj.pose.bones
 
-        owner_pb = pb[bone]
-        const = owner_pb.constraints.new(constraint['constraint'])
-        const.target = self.obj
+        # Setting the torso's props
+        torso = bones['pivot']['ctrl']
 
-        # filter contraint props to those that actually exist in the currnet
-        # type of constraint, then assign values to each
-        for p in [k for k in constraint.keys() if k in dir(const)]:
-            setattr(const, p, constraint[p])
-
-    def constrain_bones(self, bones):
         # MCH bones
-
         # head and neck MCH bones
-        for b in [bones['neck']['mch_head'], bones['neck']['mch_neck']]:
-            if b:
-                self.make_constraint(b, {
-                    'constraint': 'COPY_ROTATION',
-                    'subtarget': bones['pivot']['ctrl'],
-                })
-                self.make_constraint(b, {
-                    'constraint': 'COPY_SCALE',
-                    'subtarget': bones['pivot']['ctrl'],
-                })
+        mch_head = bones['neck']['mch_head']
+        if mch_head:
+            con = self.make_constraint(mch_head, 'COPY_ROTATION', torso)
+            self.make_constraint(mch_head, 'COPY_SCALE', torso)
+
+            self.make_property(torso, 'head_follow', default=0.0)
+            self.make_driver(con, 'influence', variables=[[torso, 'head_follow']], polynomial=[1,-1])
+
+        mch_neck = bones['neck']['mch_neck']
+        if mch_neck:
+            con = self.make_constraint(mch_neck, 'COPY_ROTATION', torso)
+            self.make_constraint(mch_neck, 'COPY_SCALE', torso)
+
+            self.make_property(torso, 'neck_follow', default=0.5)
+            self.make_driver(con, 'influence', variables=[[torso, 'neck_follow']], polynomial=[1,-1])
 
         if bones['neck']['mch_str']:
             # Neck MCH Stretch
-            self.make_constraint(bones['neck']['mch_str'], {
-                'constraint': 'DAMPED_TRACK',
-                'subtarget': bones['neck']['ctrl'],
-            })
-            self.make_constraint(bones['neck']['mch_str'], {
-                'constraint': 'STRETCH_TO',
-                'subtarget': bones['neck']['ctrl'],
-            })
+            self.make_constraint(bones['neck']['mch_str'], 'DAMPED_TRACK', bones['neck']['ctrl'])
+            self.make_constraint(bones['neck']['mch_str'], 'STRETCH_TO', bones['neck']['ctrl'])
 
         # Intermediary mch bones
         intermediaries = [bones['neck'], bones['chest'], bones['hips']]
@@ -607,49 +599,27 @@ class Rig:
 
                 if i == 0:      # Neck mch-s
                     if len(bones['neck']['original_names']) > 3:
-                        self.make_constraint(b, {
-                            'constraint': 'COPY_LOCATION',
-                            'subtarget': org(l['original_names'][j+1]),
-                            'influence': 1.0
-                        })
+                        self.make_constraint(b, 'COPY_LOCATION', org(l['original_names'][j+1]), influence=1.0)
                     else:
                         nfactor = float((j + 1) / len(mch))
-                        self.make_constraint(b, {
-                            'constraint': 'COPY_ROTATION',
-                            'subtarget': l['ctrl'],
-                            'influence': nfactor
-                        })
+                        self.make_constraint(b, 'COPY_ROTATION', l['ctrl'], influence=nfactor)
 
                     step = 2/(len(mch)+1)
                     xval = (j+1)*step
                     influence = 2*xval - xval**2    #parabolic influence of pivot
 
                     if bones['neck']['neck_bend']:
-                        self.make_constraint(b, {
-                            'constraint': 'COPY_LOCATION',
-                            'subtarget': l['neck_bend'],
-                            'influence': influence,
-                            'use_offset': True,
-                            'owner_space': 'LOCAL',
-                            'target_space': 'LOCAL'
-                        })
+                        self.make_constraint(
+                            b, 'COPY_LOCATION', l['neck_bend'],
+                            influence=influence, use_offset=True, space='LOCAL'
+                        )
 
                     if len(bones['neck']['original_names']) > 3:
-                        self.make_constraint(b, {
-                            'constraint': 'COPY_SCALE',
-                            'subtarget': org(l['original_names'][j+1]),
-                            'influence': 1.0
-                        })
+                        self.make_constraint(b, 'COPY_SCALE', org(l['original_names'][j+1]), influence=1.0)
 
                 else:
                     factor = float(1 / len(l['tweak']))
-                    self.make_constraint(b, {
-                        'constraint': 'COPY_TRANSFORMS',
-                        'subtarget': l['ctrl'],
-                        'influence': factor,
-                        'owner_space': 'LOCAL',
-                        'target_space': 'LOCAL'
-                    })
+                    self.make_constraint(b, 'COPY_TRANSFORMS', l['ctrl'], influence=factor, space='LOCAL')
 
         # Tail ctrls
         if self.use_tail:
@@ -657,32 +627,20 @@ class Rig:
             tail_ctrl.append(bones['tail']['ctrl_tail'])
 
             for i, b in enumerate(tail_ctrl[:-1]):
-                self.make_constraint(b, {
-                    'constraint': 'COPY_ROTATION',
-                    'subtarget': tail_ctrl[i+1],
-                    'influence': 1.0,
-                    'use_x': self.copy_rotation_axes[0],
-                    'use_y': self.copy_rotation_axes[1],
-                    'use_z': self.copy_rotation_axes[2],
-                    'use_offset': True,
-                    'owner_space': 'LOCAL',
-                    'target_space': 'LOCAL'
-                })
+                self.make_constraint(
+                    b, 'COPY_ROTATION', tail_ctrl[i+1], influence=1.0,
+                    use_xyz=self.copy_rotation_axes, use_offset=True, space='LOCAL'
+                )
 
             b = bones['tail']['mch_tail']
-            self.make_constraint(b, {
-                'constraint': 'COPY_ROTATION',
-                'subtarget': bones['pivot']['ctrl'],
-                'influence': 1.0,
-            })
+            con = self.make_constraint(b, 'COPY_ROTATION', bones['pivot']['ctrl'], influence=1.0)
+
+            self.make_property(torso, 'tail_follow', default=0.0)
+            self.make_driver(con, 'influence', variables=[[torso, 'tail_follow']], polynomial=[1,-1])
+
 
         # MCH pivot
-        self.make_constraint(bones['pivot']['mch'], {
-            'constraint': 'COPY_TRANSFORMS',
-            'subtarget': bones['hips']['mch'][-1],
-            'owner_space': 'LOCAL',
-            'target_space': 'LOCAL'
-        })
+        self.make_constraint(bones['pivot']['mch'], 'COPY_TRANSFORMS', bones['hips']['mch'][-1], space='LOCAL')
 
         # DEF bones
         deform = bones['def']
@@ -697,28 +655,15 @@ class Rig:
         for d, t in zip(deform, tweaks):
             tidx = tweaks.index(t)
 
-            self.make_constraint(d, {
-                'constraint': 'COPY_TRANSFORMS',
-                'subtarget': t
-            })
+            self.make_constraint(d, 'COPY_TRANSFORMS', t)
 
             if tidx != len(tweaks) - 1:
                 if self.use_tail and t in bones['tail']['tweak']:
-                    self.make_constraint(d, {
-                        'constraint': 'DAMPED_TRACK',
-                        'subtarget': tweaks[tidx + 1],
-                        'track_axis': 'TRACK_NEGATIVE_Y'
-                    })
+                    self.make_constraint(d, 'DAMPED_TRACK', tweaks[tidx + 1], track_axis='-Y')
                 else:
-                    self.make_constraint(d, {
-                        'constraint': 'DAMPED_TRACK',
-                        'subtarget': tweaks[tidx + 1],
-                    })
+                    self.make_constraint(d, 'DAMPED_TRACK', tweaks[tidx + 1])
 
-                self.make_constraint(d, {
-                    'constraint': 'STRETCH_TO',
-                    'subtarget': tweaks[tidx + 1],
-                })
+                self.make_constraint(d, 'STRETCH_TO', tweaks[tidx + 1])
 
         pb = self.obj.pose.bones
 
@@ -735,67 +680,11 @@ class Rig:
         # make IK on neck ORGs
         if len(original_neck_bones) > 3:
             last_neck = original_neck_bones[-2]
-            self.make_constraint(last_neck, {
-                'constraint': 'IK',
-                'subtarget': bones['neck']['ctrl'],
-                'chain_count': len(original_neck_bones) - 1
-            })
+            self.make_constraint(last_neck, 'IK', bones['neck']['ctrl'], chain_count=len(original_neck_bones)-1)
 
             for b in original_neck_bones[:-1]:
                 pb[b].ik_stretch = 0.1
 
-    def create_drivers(self, bones):
-        bpy.ops.object.mode_set(mode='OBJECT')
-        pb = self.obj.pose.bones
-
-        # Setting the torso's props
-        torso = pb[bones['pivot']['ctrl']]
-
-        props = []
-        owners = []
-
-        if self.use_head:
-            props += ["head_follow"]
-            owners += [bones['neck']['mch_head']]
-            if bones['neck']['mch_neck']:
-                props += ["neck_follow"]
-                owners += [bones['neck']['mch_neck']]
-        if self.use_tail:
-            props += ["tail_follow"]
-            owners += [bones['tail']['mch_tail']]
-
-        for prop in props:
-            if prop == 'neck_follow':
-                torso[prop] = 0.5
-            else:
-                torso[prop] = 0.0
-
-            prop = rna_idprop_ui_prop_get(torso, prop, create=True)
-            prop["min"] = 0.0
-            prop["max"] = 1.0
-            prop["soft_min"] = 0.0
-            prop["soft_max"] = 1.0
-            prop["description"] = prop
-
-        # driving the follow rotation switches for neck and head
-        for bone, prop, in zip(owners, props):
-            # Add driver to copy rotation constraint
-            drv = pb[bone].constraints[0].driver_add("influence").driver
-            drv.type = 'AVERAGE'
-
-            var = drv.variables.new()
-            var.name = prop
-            var.type = "SINGLE_PROP"
-            var.targets[0].id = self.obj
-            var.targets[0].data_path = \
-                torso.path_from_id() + '[' + '"' + prop + '"' + ']'
-
-            drv_modifier = self.obj.animation_data.drivers[-1].modifiers[0]
-
-            drv_modifier.mode = 'POLYNOMIAL'
-            drv_modifier.poly_order = 1
-            drv_modifier.coefficients[0] = 1.0
-            drv_modifier.coefficients[1] = -1.0
 
     def locks_and_widgets(self, bones):
         bpy.ops.object.mode_set(mode='OBJECT')
@@ -981,7 +870,6 @@ class Rig:
 
             self.parent_bones(bones)
             self.constrain_bones(bones)
-            self.create_drivers(bones)
             self.locks_and_widgets(bones)
 
         else:

--- a/utils/mechanism.py
+++ b/utils/mechanism.py
@@ -1,0 +1,262 @@
+#====================== BEGIN GPL LICENSE BLOCK ======================
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+#======================= END GPL LICENSE BLOCK ========================
+
+# <pep8 compliant>
+
+import bpy
+
+from rna_prop_ui import rna_idprop_ui_prop_get
+
+#=============================================
+# Constraint creation utilities
+#=============================================
+
+_TRACK_AXIS_MAP =  {
+    'X': 'TRACK_X', '-X': 'TRACK_NEGATIVE_X',
+    'Y': 'TRACK_Y', '-Y': 'TRACK_NEGATIVE_Y',
+    'Z': 'TRACK_Z', '-Z': 'TRACK_NEGATIVE_Z',
+}
+
+def make_constraint(
+        owner, type, target=None, subtarget=None,
+        space=None, track_axis=None, use_xyz=None,
+        **options):
+    """
+    Creates and initializes constraint of the specified type for the owner bone.
+
+    Specially handled keyword arguments:
+
+      target, subtarget: if both not None, passed through to the constraint
+      space            : assigned to both owner_space and target_space
+      track_axis       : allows shorter X, Y, Z, -X, -Y, -Z notation
+      use_xyz          : list of 3 items is assigned to use_x, use_y and use_z options
+      min/max_x/y/z    : a corresponding use_min/max_x/y/z option is set to True
+
+    Other keyword arguments are directly assigned to the constraint options.
+    Returns the newly created constraint.
+    """
+    con = owner.constraints.new(type)
+
+    if target is not None and subtarget is not None:
+        con.target = target
+        con.subtarget = subtarget
+
+    if space is not None:
+        con.owner_space = con.target_space = space
+
+    if track_axis is not None:
+        con.track_axis = _TRACK_AXIS_MAP.get(track_axis, track_axis)
+
+    if use_xyz is not None:
+        con.use_x, con.use_y, con.use_z = use_xyz[0:3]
+
+    for key in ['min_x', 'max_x', 'min_y', 'max_y', 'min_z', 'max_z']:
+        if key in options and 'use_'+key not in options:
+            options['use_'+key] = True
+
+    for p, v in options.items():
+        setattr(con, p, v)
+
+    return con
+
+#=============================================
+# Custom property creation utilities
+#=============================================
+
+def make_property(owner, name, default=0.0, min=0.0, max=1.0, soft_min=None, soft_max=None):
+    """
+    Creates and initializes a custom property of owner.
+
+    The soft_min and soft_max parameters default to min and max.
+    """
+    owner[name] = default
+
+    prop = rna_idprop_ui_prop_get(owner, name, create=True)
+    prop["min"] = min
+    prop["soft_min"] = soft_min if soft_min is not None else min
+    prop["max"] = max
+    prop["soft_max"] = soft_max if soft_max is not None else max
+
+    return prop
+
+#=============================================
+# Driver creation utilities
+#=============================================
+
+def _init_driver_target(drv_target, var_info, target_id):
+    """Initialize a driver variable target from a specification."""
+
+    # Parse the simple list format for the common case.
+    if isinstance(var_info, list):
+        # [ (target_id,) subtarget, ...path ]
+
+        # If target_id is supplied as parameter, allow omitting it
+        if target_id is None or isinstance(var_info[0], bpy.types.ID):
+            target_id,subtarget,*refs = var_info
+        else:
+            subtarget,*refs = var_info
+
+        # Simple path string case.
+        if len(refs) == 0:
+            # [ (target_id,) path_str ]
+            path = subtarget
+        else:
+            # If subtarget is a string, look up a bone in the target
+            if isinstance(subtarget, str):
+                subtarget = target_id.pose.bones[subtarget]
+
+            # Use ".foo" type path items verbatim, otherwise quote
+            path = subtarget.path_from_id()
+            for item in refs:
+                path += item if item[0] == '.' else '["'+item+'"]'
+
+        drv_target.id = target_id
+        drv_target.data_path = path
+
+    else:
+        # { 'id': ..., ... }
+        if target_id is not None:
+            drv_target.id = target_id
+
+        for tp, tv in tdata.items():
+            setattr(drv_target, tp, tv)
+
+
+def _add_driver_variable(drv, var_name, var_info, target_id):
+    """Add and initialize a driver variable."""
+
+    var = drv.variables.new()
+    var.name = var_name
+
+    # Parse the simple list format for the common case.
+    if isinstance(var_info, list):
+        # [ (target_id,) subtarget, ...path ]
+        var.type = "SINGLE_PROP"
+
+        _init_driver_target(var.targets[0], var_info, target_id)
+
+    else:
+        # Variable info as generic dictionary - assign properties.
+        # { 'type': 'SINGLE_PROP', 'targets':[...] }
+        var.type = var_info['type']
+
+        for p, v in var_info.items():
+            if p == 'targets':
+                for i, tdata in enumerate(v):
+                    _init_driver_target(var.targets[i], tdata, target_id)
+            elif p != 'type':
+                setattr(var, p, v)
+
+def make_driver(owner, prop, index=-1, type='SUM', expression=None, variables={}, polynomial=None, target_id=None):
+    """
+    Creates and initializes a driver for the 'prop' property of owner.
+
+    Arguments:
+      index           : item index for vector properties
+      type, expression: mutually exclusive options to set core driver mode.
+      variables       : either a list or dictionary of variable specifications.
+      polynomial      : coefficients of the POLYNOMIAL driver modifier
+      target_id       : specifies the target ID of variables implicitly
+
+    Specification format:
+        If the variables argument is a dictionary, keys specify variable names.
+        Otherwise names are set to var0, var1... etc:
+
+          variables = [ ..., ..., ... ]
+          variables = { 'var0': ..., 'var1': ..., 'var2': ... }
+
+        Variable specifications are constructed as nested dictionaries and lists that
+        follow the property structure of the original Blender objects, but the most
+        common case can be abbreviated as a simple list.
+
+        The following specifications are equivalent:
+
+          [ target, subtarget, '.foo', 'bar' ]
+
+          { 'type': 'SINGLE_PROP', 'targets':[[ target, subtarget, '.foo', 'bar' ]] }
+
+          { 'type': 'SINGLE_PROP',
+            'targets':[{ 'id': target, 'data_path': subtarget.path_from_id() + '.foo["bar"]' }] }
+
+        If subtarget is as string, it is automatically looked up within target as a bone.
+
+        It is possible to specify path directly as a simple string without following items:
+
+          [ target, 'path' ]
+
+          { 'type': 'SINGLE_PROP', 'targets':[{ 'id': target, 'data_path': 'path' }] }
+
+        If the target_id parameter is not None, it is possible to omit target:
+
+          [ subtarget, '.foo', 'bar' ]
+
+          { 'type': 'SINGLE_PROP',
+            'targets':[{ 'id': target_id, 'data_path': subtarget.path_from_id() + '.foo["bar"]' }] }
+
+    Returns the newly created driver FCurve.
+    """
+    fcu = owner.driver_add(prop, index)
+    drv = fcu.driver
+
+    if expression is not None:
+        drv.type = 'SCRIPTED'
+        drv.expression = expression
+    else:
+        drv.type = type
+
+    if isinstance(variables, list):
+        # variables = [ info, ... ]
+        for i, var_info in enumerate(variables):
+            _add_driver_variable(drv, 'var'+str(i), var_info, target_id)
+    else:
+        # variables = { 'varname': info, ... }
+        for var_name, var_info in variables.items():
+            _add_driver_variable(drv, var_name, var_info, target_id)
+
+    if polynomial is not None:
+        drv_modifier = fcu.modifiers[0]
+        drv_modifier.mode = 'POLYNOMIAL'
+        drv_modifier.poly_order = len(polynomial)-1
+        for i,v in enumerate(polynomial):
+            drv_modifier.coefficients[i] = v
+
+    return fcu
+
+#=============================================
+# Utility mixin
+#=============================================
+
+class MechanismUtilityMixin:
+    """
+    Provides methods for more convenient creation of constraints, properties
+    and drivers within an armature (by implicitly providing context).
+
+    Requires self.obj to be the armature object being worked on.
+    """
+
+    def make_constraint(self, bone, type, subtarget=None, **args):
+        assert(self.obj.mode == 'OBJECT')
+        return make_constraint(self.obj.pose.bones[bone], type, self.obj, subtarget, **args)
+
+    def make_property(self, bone, name, **args):
+        assert(self.obj.mode == 'OBJECT')
+        return make_property(self.obj.pose.bones[bone], name, **args)
+
+    def make_driver(self, owner, prop, **args):
+        assert(self.obj.mode == 'OBJECT')
+        return make_driver(owner, prop, target_id=self.obj, **args)


### PR DESCRIPTION
Add convenient utilities for creating constraints, properties and drivers.

Also, add a dictionary type specifically intended for holding bone names which allows access to items as attributes (i.e. bones.foo instead of the cumbersome bones['foo'] syntax).

All this aims to make the mechanism creation code cleaner and easier to write by removing copy&pasted boilerplate and excess punctuation.

The spine rig code is modified to use the new utilities as an example (without changing any functionality).