### PR TITLE
Adjust the glue API.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -449,6 +449,13 @@ def generate_rig(context, metarig):
         if obj.data.bones[bone].name.startswith(DEF_PREFIX):
             obj.data.bones[bone].layers = DEF_LAYER
 
+    # Do final gluing
+    for rig in rigs:
+        if hasattr(rig, "glue"):
+            rig.glue(rigs)
+
+    t.tick("Glue pass")
+
     # Create root bone widget
     create_root_widget(obj, "root")
 
@@ -542,16 +549,6 @@ def generate_rig(context, metarig):
         bpy.ops.logic.controller_add(type='PYTHON', object=obj.name)
         ctrl = obj.game.controllers[-1]
         ctrl.text = bpy.data.texts[script.name]
-
-    # Do final gluing
-    for rig in rigs:
-        if hasattr(rig, "glue"):
-            # update glue_bone rigs
-            bpy.ops.object.mode_set(mode='EDIT')
-            rig = rig.__class__(rig.obj, rig.base_bone, rig.params)
-
-            rig.glue()
-    t.tick("Glue pass")
 
     t.tick("The rest: ")
     #----------------------------------

--- a/rigs/experimental/glue_bone.py
+++ b/rigs/experimental/glue_bone.py
@@ -154,7 +154,7 @@ class Rig(BaseRig):
         make_constraints_from_string(owner_pb, target=self.obj, subtarget=subtarget,
                                      fstring="CT1.0WW")
 
-    def glue(self):
+    def do_glue(self):
         """
         Glue pass
         :return:
@@ -166,6 +166,11 @@ class Rig(BaseRig):
         elif self.glue_mode == "def_mediator":
             self.create_mch()
             self.make_def_mediation()
+
+    def glue(self, rigs):
+        bpy.ops.object.mode_set(mode='EDIT')
+        rig_new = self.__class__(self.obj, self.base_bone, self.params)
+        rig_new.do_glue()
 
     def generate(self):
         """


### PR DESCRIPTION
1. Move the rig class reinitialization code to glue_bone, because
   it is obviously specific to it, and making it global reduces
   the usefulness of the interface.
2. Pass the rig list to the method so that rigs could potentially interact.
3. Move the call before the script, widgets and bone groups are finalized.