### PR TITLE
Update the branch with changes from upstream 2.8 master.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,7 @@
 
 bl_info = {
     "name": "Rigify",
-    "version": (0, 5),
+    "version": (0, 5, 1),
     "author": "Nathan Vegdahl, Lucio Rossi, Ivan Cappiello",
     "blender": (2, 78, 0),
     "description": "Automatic rigging from building-block components",
@@ -363,7 +363,7 @@ def register():
     bpy.types.Armature.active_feature_set = bpy.props.EnumProperty(
         items=feature_sets.feature_set_items,
         name="Feature Set",
-        description="Feature set to select from for this bone"
+        description="Restrict the rig list to a specific custom feature set"
         )
 
     bpy.types.PoseBone.rigify_type = bpy.props.StringProperty(name="Rigify Type", description="Rig type for this bone")

--- a/__init__.py
+++ b/__init__.py
@@ -258,7 +258,17 @@ class RigifyParameters(bpy.types.PropertyGroup):
     name = bpy.props.StringProperty()
 
 
+# Remember the initial property set
+RIGIFY_PARAMETERS_BASE_DIR = set(dir(RigifyParameters))
+
 RIGIFY_PARAMETER_TABLE = {'name': ('DEFAULT', bpy.props.StringProperty())}
+
+def clear_rigify_parameters():
+    for name in list(dir(RigifyParameters)):
+        if name not in RIGIFY_PARAMETERS_BASE_DIR:
+            delattr(RigifyParameters, name)
+            if name in RIGIFY_PARAMETER_TABLE:
+                del RIGIFY_PARAMETER_TABLE[name]
 
 
 def format_property_spec(spec):
@@ -488,6 +498,9 @@ def unregister():
     if "bl_rna" in RigifyPreferences.__dict__:
         bpy.utils.unregister_class(RigifyPreferences)
 
+    clear_rigify_parameters()
+
+    # Sub-modules.
     metarig_menu.unregister()
     ui.unregister()
     feature_sets.unregister()

--- a/legacy/rigs/biped/arm/__init__.py
+++ b/legacy/rigs/biped/arm/__init__.py
@@ -117,7 +117,7 @@ def add_parameters(params):
 
     """
     params.use_complex_arm = bpy.props.BoolProperty(name="Complex Arm Rig", default=True, description="Generate the full, complex arm rig with twist bones and rubber-hose controls")
-    params.bend_hint = bpy.props.BoolProperty(name="Bend Hint", default=True, description="Give IK chain a hint about which way to bend.  Useful for perfectly straight chains")
+    params.bend_hint = bpy.props.BoolProperty(name="Bend Hint", default=True, description="Give IK chain a hint about which way to bend. Useful for perfectly straight chains")
 
     items = [('X', 'X', ''), ('Y', 'Y', ''), ('Z', 'Z', ''), ('-X', '-X', ''), ('-Y', '-Y', ''), ('-Z', '-Z', '')]
     params.primary_rotation_axis = bpy.props.EnumProperty(items=items, name="Primary Rotation Axis", default='X')

--- a/legacy/rigs/biped/leg/__init__.py
+++ b/legacy/rigs/biped/leg/__init__.py
@@ -121,7 +121,7 @@ def add_parameters(params):
 
     """
     params.use_complex_leg = bpy.props.BoolProperty(name="Complex Leg Rig", default=True, description="Generate the full, complex leg rig with twist bones and rubber-hose controls")
-    params.bend_hint = bpy.props.BoolProperty(name="Bend Hint", default=True, description="Give IK chain a hint about which way to bend (useful for perfectly straight chains)")
+    params.bend_hint = bpy.props.BoolProperty(name="Bend Hint", default=True, description="Give IK chain a hint about which way to bend. Useful for perfectly straight chains")
 
     items = [('X', 'X', ''), ('Y', 'Y', ''), ('Z', 'Z', ''), ('-X', '-X', ''), ('-Y', '-Y', ''), ('-Z', '-Z', '')]
     params.primary_rotation_axis = bpy.props.EnumProperty(items=items, name="Primary Rotation Axis", default='X')

--- a/legacy/rigs/biped/limb_common.py
+++ b/legacy/rigs/biped/limb_common.py
@@ -19,7 +19,6 @@
 from math import pi
 
 import bpy
-from rna_prop_ui import rna_idprop_ui_prop_get
 from mathutils import Vector
 
 from ...utils import angle_on_plane, align_bone_roll, align_bone_z_axis
@@ -27,6 +26,7 @@ from ...utils import new_bone, copy_bone, put_bone, make_nonscaling_child
 from ...utils import strip_org, make_mechanism_name, make_deformer_name, insert_before_lr
 from ...utils import create_widget, create_limb_widget, create_line_widget, create_sphere_widget
 
+from ....utils.mechanism import make_property
 
 class FKLimb:
     def __init__(self, obj, bone1, bone2, bone3, primary_rotation_axis, layers):
@@ -155,17 +155,9 @@ class FKLimb:
 
         # Set up custom properties
         if parent is not None:
-            prop = rna_idprop_ui_prop_get(ulimb_p, "isolate", create=True)
-            ulimb_p["isolate"] = 0.0
-            prop["soft_min"] = prop["min"] = 0.0
-            prop["soft_max"] = prop["max"] = 1.0
+            make_property(ulimb_p, "isolate", 0.0)
 
-        prop = rna_idprop_ui_prop_get(ulimb_p, "stretch_length", create=True)
-        ulimb_p["stretch_length"] = 1.0
-        prop["min"] = 0.05
-        prop["max"] = 20.0
-        prop["soft_min"] = 0.25
-        prop["soft_max"] = 4.0
+        make_property(ulimb_p, "stretch_length", 1.0, min=0.05, max=20.0, soft_min=0.25, soft_max=4.0)
 
         # Stretch drivers
         def add_stretch_drivers(pose_bone):
@@ -501,28 +493,13 @@ class IKLimb:
 
         # Set up custom properties
         if self.switch is True:
-            prop = rna_idprop_ui_prop_get(elimb_p, "ikfk_switch", create=True)
-            elimb_p["ikfk_switch"] = 0.0
-            prop["soft_min"] = prop["min"] = 0.0
-            prop["soft_max"] = prop["max"] = 1.0
+            make_property(elimb_p, "ikfk_switch", 0.0)
 
         if self.pole_parent is not None:
-            prop = rna_idprop_ui_prop_get(pole_p, "follow", create=True)
-            pole_p["follow"] = 1.0
-            prop["soft_min"] = prop["min"] = 0.0
-            prop["soft_max"] = prop["max"] = 1.0
+            make_property(pole_p, "follow", 1.0)
 
-        prop = rna_idprop_ui_prop_get(elimb_p, "stretch_length", create=True)
-        elimb_p["stretch_length"] = 1.0
-        prop["min"] = 0.05
-        prop["max"] = 20.0
-        prop["soft_min"] = 0.25
-        prop["soft_max"] = 4.0
-
-        prop = rna_idprop_ui_prop_get(elimb_p, "auto_stretch", create=True)
-        elimb_p["auto_stretch"] = 1.0
-        prop["soft_min"] = prop["min"] = 0.0
-        prop["soft_max"] = prop["max"] = 1.0
+        make_property(elimb_p, "stretch_length", 1.0, min=0.05, max=20.0, soft_min=0.25, soft_max=4.0)
+        make_property(elimb_p, "auto_stretch", 1.0)
 
         # Stretch parameter drivers
         def add_stretch_drivers(pose_bone):
@@ -1096,10 +1073,7 @@ class RubberHoseLimb:
             flimb1_smoother_p.bone.bbone_out = 1.0
 
             # Custom properties
-            prop = rna_idprop_ui_prop_get(jhose_p, "smooth_bend", create=True)
-            jhose_p["smooth_bend"] = 0.0
-            prop["soft_min"] = prop["min"] = 0.0
-            prop["soft_max"] = prop["max"] = 1.0
+            make_property(jhose_p, "smooth_bend", 0.0)
 
             # Constraints
             con = ulimb1_p.constraints.new('COPY_LOCATION')

--- a/legacy/rigs/finger.py
+++ b/legacy/rigs/finger.py
@@ -21,7 +21,6 @@
 import re
 
 import bpy
-from rna_prop_ui import rna_idprop_ui_prop_get
 from mathutils import Vector
 
 from ..utils import MetarigError
@@ -30,6 +29,7 @@ from ..utils import connected_children_names
 from ..utils import strip_org, make_mechanism_name, make_deformer_name
 from ..utils import create_widget, create_limb_widget
 
+from ...utils.mechanism import make_property
 
 class Rig:
     """ A finger rig.  It takes a single chain of bones.
@@ -187,15 +187,12 @@ class Rig:
         for bone in helpers:
             # Add custom prop
             prop_name = "bend_%02d" % i
-            prop = rna_idprop_ui_prop_get(pb[ctrl], prop_name, create=True)
-            prop["min"] = 0.0
-            prop["max"] = 1.0
-            prop["soft_min"] = 0.0
-            prop["soft_max"] = 1.0
             if i == 1:
-                pb[ctrl][prop_name] = 0.0
+                propval = 0.0
             else:
-                pb[ctrl][prop_name] = val
+                propval = val
+
+            make_property(pb[ctrl], prop_name, propval)
 
             # Add driver
             if 'X' in self.primary_rotation_axis:

--- a/legacy/rigs/neck_short.py
+++ b/legacy/rigs/neck_short.py
@@ -19,7 +19,6 @@
 # <pep8 compliant>
 
 import bpy
-from rna_prop_ui import rna_idprop_ui_prop_get
 
 from ..utils import MetarigError
 from ..utils import copy_bone, new_bone, put_bone
@@ -27,6 +26,7 @@ from ..utils import connected_children_names
 from ..utils import strip_org, make_mechanism_name, make_deformer_name
 from ..utils import create_circle_widget
 
+from ...utils.mechanism import make_property
 
 script1 = """
 head_neck = ["%s", "%s"]
@@ -190,27 +190,11 @@ class Rig:
         head_ctrl_p.custom_shape_transform = pb[self.org_bones[-1]]
 
         # Custom properties
-        prop = rna_idprop_ui_prop_get(head_ctrl_p, "inf_extent", create=True)
-        head_ctrl_p["inf_extent"] = 0.5
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-
-        prop = rna_idprop_ui_prop_get(head_ctrl_p, "neck_follow", create=True)
-        head_ctrl_p["neck_follow"] = 1.0
-        prop["min"] = 0.0
-        prop["max"] = 2.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
+        make_property(head_ctrl_p, "inf_extent", 0.5)
+        make_property(head_ctrl_p, "neck_follow", 1.0, max=2.0, soft_max=1.0)
 
         if self.isolate:
-            prop = rna_idprop_ui_prop_get(head_ctrl_p, "isolate", create=True)
-            head_ctrl_p["isolate"] = 0.0
-            prop["min"] = 0.0
-            prop["max"] = 1.0
-            prop["soft_min"] = 0.0
-            prop["soft_max"] = 1.0
+            make_property(head_ctrl_p, "isolate", 0.0)
 
         # Constraints
 

--- a/legacy/rigs/pitchipoy/limbs/arm.py
+++ b/legacy/rigs/pitchipoy/limbs/arm.py
@@ -23,7 +23,8 @@ from ....utils       import create_widget, copy_bone
 from ....utils       import strip_org
 from .limb_utils     import *
 from ..super_widgets import create_hand_widget
-from rna_prop_ui     import rna_idprop_ui_prop_get
+
+from .....utils.mechanism import make_property
 
 def create_arm( cls, bones ):
     org_bones = cls.org_bones
@@ -81,13 +82,7 @@ def create_arm( cls, bones ):
     # Create ik/fk switch property
     pb_parent = pb[ bones['parent'] ]
 
-    pb_parent['IK_Strertch'] = 1.0
-    prop = rna_idprop_ui_prop_get( pb_parent, 'IK_Strertch', create=True )
-    prop["min"]         = 0.0
-    prop["max"]         = 1.0
-    prop["soft_min"]    = 0.0
-    prop["soft_max"]    = 1.0
-    prop["description"] = 'IK Stretch'
+    prop = make_property(pb_parent, 'IK_Strertch', 1.0, description='IK Stretch')
 
     # Add driver to limit scale constraint influence
     b        = bones['ik']['mch_str']

--- a/legacy/rigs/pitchipoy/limbs/leg.py
+++ b/legacy/rigs/pitchipoy/limbs/leg.py
@@ -25,6 +25,8 @@ from rna_prop_ui     import rna_idprop_ui_prop_get
 from ..super_widgets import create_foot_widget, create_ballsocket_widget
 from .limb_utils     import *
 
+from .....utils.mechanism import make_property
+
 def create_leg( cls, bones ):
     org_bones = list(
         [cls.org_bones[0]] + connected_children_names(cls.obj, cls.org_bones[0])
@@ -236,13 +238,7 @@ def create_leg( cls, bones ):
     # Create ik/fk switch property
     pb_parent = pb[ bones['parent'] ]
 
-    pb_parent['IK_Strertch'] = 1.0
-    prop = rna_idprop_ui_prop_get( pb_parent, 'IK_Strertch', create=True )
-    prop["min"]         = 0.0
-    prop["max"]         = 1.0
-    prop["soft_min"]    = 0.0
-    prop["soft_max"]    = 1.0
-    prop["description"] = 'IK Stretch'
+    prop = make_property(pb_parent, 'IK_Strertch', 1.0, description='IK Stretch')
 
     # Add driver to limit scale constraint influence
     b        = bones['ik']['mch_str']

--- a/legacy/rigs/pitchipoy/limbs/paw.py
+++ b/legacy/rigs/pitchipoy/limbs/paw.py
@@ -25,6 +25,8 @@ from rna_prop_ui     import rna_idprop_ui_prop_get
 from ..super_widgets import create_foot_widget, create_ballsocket_widget
 from .limb_utils     import *
 
+from .....utils.mechanism import make_property
+
 def create_paw( cls, bones ):
     org_bones = list(
         [cls.org_bones[0]] + connected_children_names(cls.obj, cls.org_bones[0])
@@ -105,13 +107,7 @@ def create_paw( cls, bones ):
     # Create ik/fk switch property
     pb_parent = pb[ bones['parent'] ]
 
-    pb_parent['IK_Strertch'] = 1.0
-    prop = rna_idprop_ui_prop_get( pb_parent, 'IK_Strertch', create=True )
-    prop["min"]         = 0.0
-    prop["max"]         = 1.0
-    prop["soft_min"]    = 0.0
-    prop["soft_max"]    = 1.0
-    prop["description"] = 'IK Stretch'
+    prop = make_property(pb_parent, 'IK_Strertch', 1.0, description='IK Stretch')
 
     # Add driver to limit scale constraint influence
     b        = bones['ik']['mch_str']

--- a/legacy/rigs/pitchipoy/limbs/super_limb.py
+++ b/legacy/rigs/pitchipoy/limbs/super_limb.py
@@ -10,10 +10,10 @@ from   ....utils       import strip_org, make_deformer_name, create_widget
 from   ....utils       import create_circle_widget, create_sphere_widget
 from   ....utils       import MetarigError, make_mechanism_name, org
 from   ....utils       import create_limb_widget, connected_children_names
-from   rna_prop_ui     import rna_idprop_ui_prop_get
 from   ..super_widgets import create_ikarrow_widget
 from   math            import trunc
 
+from .....utils.mechanism import make_property
 
 class Rig:
 
@@ -79,14 +79,7 @@ class Rig:
 
         name = 'FK_limb_follow'
 
-        pb[ mch ][ name ] = 0.0
-        prop = rna_idprop_ui_prop_get( pb[ mch ], name, create = True )
-
-        prop["min"]         = 0.0
-        prop["max"]         = 1.0
-        prop["soft_min"]    = 0.0
-        prop["soft_max"]    = 1.0
-        prop["description"] = name
+        make_property(pb[ mch ], name, 0.0)
 
         drv = pb[ mch ].constraints[ 0 ].driver_add("influence").driver
 
@@ -335,17 +328,11 @@ class Rig:
             name = 'rubber_tweak'
 
             if i == trunc( len( tweaks[1:-1] ) / 2 ):
-                pb[t][name] = 0.0
+                defval = 0.0
             else:
-                pb[t][name] = 1.0
+                defval = 1.0
 
-            prop = rna_idprop_ui_prop_get( pb[t], name, create=True )
-
-            prop["min"]         = 0.0
-            prop["max"]         = 2.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = name
+            make_property(pb[t], name, defval, max=2.0, soft_max=1.0)
 
         for j,d in enumerate(def_bones[:-1]):
             drvs = {}
@@ -498,13 +485,7 @@ class Rig:
         pb_parent = pb[ parent ]
 
         # Create ik/fk switch property
-        pb_parent['IK/FK']  = 0.0
-        prop = rna_idprop_ui_prop_get( pb_parent, 'IK/FK', create=True )
-        prop["min"]         = 0.0
-        prop["max"]         = 1.0
-        prop["soft_min"]    = 0.0
-        prop["soft_max"]    = 1.0
-        prop["description"] = 'IK/FK Switch'
+        prop = make_property(pb_parent, 'IK/FK', 0.0, description='IK/FK Switch')
 
         # Constrain org to IK and FK bones
         iks =  [ ik['ctrl']['limb'] ]

--- a/legacy/rigs/pitchipoy/super_face.py
+++ b/legacy/rigs/pitchipoy/super_face.py
@@ -4,9 +4,9 @@ from   ...utils       import copy_bone, flip_bone
 from   ...utils       import org, strip_org, make_deformer_name, connected_children_names, make_mechanism_name
 from   ...utils       import create_circle_widget, create_sphere_widget, create_widget, create_cube_widget
 from   ...utils       import MetarigError
-from   rna_prop_ui    import rna_idprop_ui_prop_get
 from   .super_widgets import create_face_widget, create_eye_widget, create_eyes_widget, create_ear_widget, create_jaw_widget, create_teeth_widget
 
+from ....utils.mechanism import make_property
 
 script = """
 all_controls   = [%s]
@@ -917,16 +917,11 @@ class Rig:
 
         for bone, prop_name in zip( [ jaw_ctrl, eyes_ctrl ], [ jaw_prop, eyes_prop ] ):
             if bone == jaw_ctrl:
-                pb[ bone ][ prop_name ] = 0.0
+                defval = 0.0
             else:
-                pb[ bone ][ prop_name ] = 1.0
+                defval = 1.0
 
-            prop = rna_idprop_ui_prop_get( pb[ bone ], prop_name )
-            prop["min"]         = 0.0
-            prop["max"]         = 1.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = prop_name
+            make_property(pb[ bone ], prop_name, defval)
 
         # Jaw drivers
         mch_jaws = all_bones['mch']['jaw'][1:-1]

--- a/legacy/rigs/pitchipoy/super_finger.py
+++ b/legacy/rigs/pitchipoy/super_finger.py
@@ -4,7 +4,8 @@ from ...utils import copy_bone, flip_bone
 from ...utils import strip_org, make_deformer_name, connected_children_names, make_mechanism_name
 from ...utils import create_circle_widget, create_sphere_widget, create_widget
 from ...utils import MetarigError
-from rna_prop_ui import rna_idprop_ui_prop_get
+
+from ....utils.mechanism import make_property
 
 script = """
 controls    = [%s]
@@ -149,13 +150,7 @@ class Rig:
         pb[tip_name].lock_rotation   = True,True,True
         pb[tip_name].lock_rotation_w = True
 
-        pb_master['finger_curve'] = 0.0
-        prop = rna_idprop_ui_prop_get(pb_master, 'finger_curve')
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = "Rubber hose finger cartoon effect"
+        make_property(pb_master, 'finger_curve', 0.0, description="Rubber hose finger cartoon effect")
 
         # Pose settings
         for org, ctrl, deform, mch, mch_drv in zip(self.org_bones, ctrl_chain, def_chain, mch_chain, mch_drv_chain):

--- a/legacy/rigs/pitchipoy/super_torso_turbo.py
+++ b/legacy/rigs/pitchipoy/super_torso_turbo.py
@@ -4,7 +4,8 @@ from ...utils import copy_bone, flip_bone, put_bone, org
 from ...utils import strip_org, make_deformer_name, connected_children_names
 from ...utils import create_circle_widget, create_sphere_widget, create_widget
 from ...utils import MetarigError, make_mechanism_name, create_cube_widget
-from rna_prop_ui import rna_idprop_ui_prop_get
+
+from ....utils.mechanism import make_property
 
 script = """
 controls = [%s]
@@ -518,16 +519,11 @@ class Rig:
 
         for prop in props:
             if prop == 'neck_follow':
-                torso[prop] = 0.5
+                defval = 0.5
             else:
-                torso[prop] = 0.0
+                defval = 0.0
 
-            prop = rna_idprop_ui_prop_get( torso, prop, create=True )
-            prop["min"]         = 0.0
-            prop["max"]         = 1.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = prop
+            make_property(torso, prop, defval)
 
         # driving the follow rotation switches for neck and head
         for bone, prop, in zip( owners, props ):

--- a/legacy/rigs/pitchipoy/tentacle.py
+++ b/legacy/rigs/pitchipoy/tentacle.py
@@ -4,7 +4,8 @@ from ...utils    import strip_org, make_deformer_name, connected_children_names
 from ...utils    import make_mechanism_name, put_bone, create_sphere_widget
 from ...utils    import create_widget, create_circle_widget
 from ...utils    import MetarigError
-from rna_prop_ui import rna_idprop_ui_prop_get
+
+from ....utils.mechanism import make_property
 
 script = """
 controls    = [%s]
@@ -263,14 +264,7 @@ class Rig:
             prop_names = [ prop_name_r, prop_name_s ]
 
             for prop_name in prop_names:
-                master_pb[prop_name] = 1.0
-
-                prop = rna_idprop_ui_prop_get( master_pb, prop_name )
-                prop["min"] = 0.0
-                prop["max"] = 1.0
-                prop["soft_min"] = 0.0
-                prop["soft_max"] = 1.0
-                prop["description"] = prop_name
+                make_property(master_pb, prop_name, 1.0)
 
                 # driving the MCH follow rotation switch
 

--- a/legacy/rigs/spine.py
+++ b/legacy/rigs/spine.py
@@ -27,13 +27,14 @@ from math import floor
 
 import bpy
 from mathutils import Vector
-from rna_prop_ui import rna_idprop_ui_prop_get
 
 from ..utils import MetarigError
 from ..utils import copy_bone, new_bone, flip_bone, put_bone
 from ..utils import connected_children_names
 from ..utils import strip_org, make_mechanism_name, make_deformer_name
 from ..utils import create_circle_widget, create_cube_widget
+
+from ...utils.mechanism import make_property
 
 script = """
 main = "%s"
@@ -202,20 +203,10 @@ class Rig:
             bone = pb[par_name]
 
             # Custom bend_alpha property
-            prop = rna_idprop_ui_prop_get(pb[name], "bend_alpha", create=True)
-            pb[name]["bend_alpha"] = i / (len(self.org_bones) - 1)  # set bend alpha
-            prop["min"] = 0.0
-            prop["max"] = 1.0
-            prop["soft_min"] = 0.0
-            prop["soft_max"] = 1.0
+            make_property(pb[name], "bend_alpha", i / (len(self.org_bones) - 1)) # set bend alpha
 
             # Custom auto_rotate
-            prop = rna_idprop_ui_prop_get(pb[name], "auto_rotate", create=True)
-            pb[name]["auto_rotate"] = 1.0
-            prop["min"] = 0.0
-            prop["max"] = 1.0
-            prop["soft_min"] = 0.0
-            prop["soft_max"] = 1.0
+            make_property(pb[name], "auto_rotate", 1.0)
 
             # Constraints
             con1 = bone.constraints.new('COPY_TRANSFORMS')
@@ -351,12 +342,11 @@ class Rig:
         main_control_p = pb[main_control]
 
         # Custom pivot_slide property
-        prop = rna_idprop_ui_prop_get(main_control_p, "pivot_slide", create=True)
-        main_control_p["pivot_slide"] = self.pivot_rest
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 1.0 / len(self.org_bones)
-        prop["soft_max"] = 1.0 - (1.0 / len(self.org_bones))
+        make_property(
+            main_control_p, "pivot_slide", self.pivot_rest,
+            soft_min = 1.0 / len(self.org_bones),
+            soft_max = 1.0 - (1.0 / len(self.org_bones))
+        )
 
         # Anchor constraints
         con = bone_p.constraints.new('COPY_LOCATION')
@@ -408,12 +398,7 @@ class Rig:
                 for n in range(i + 1, j):
                     bone = pb[flex_subs[n]]
                     # Custom bend_alpha property
-                    prop = rna_idprop_ui_prop_get(bone, "bend_alpha", create=True)
-                    bone["bend_alpha"] = (n - i) / (j - i)  # set bend alpha
-                    prop["min"] = 0.0
-                    prop["max"] = 1.0
-                    prop["soft_min"] = 0.0
-                    prop["soft_max"] = 1.0
+                    make_property(bone, "bend_alpha", (n - i) / (j - i), overridable=False)  # set bend alpha
 
                     con = bone.constraints.new('COPY_TRANSFORMS')
                     con.name = "copy_transforms"

--- a/rigs/experimental/super_chain.py
+++ b/rigs/experimental/super_chain.py
@@ -6,7 +6,7 @@ from ...utils import strip_org, make_deformer_name, connected_children_names
 from ...utils import create_circle_widget, create_sphere_widget, create_widget, create_chain_widget
 from ...utils import MetarigError, make_mechanism_name, create_cube_widget
 from ...utils import ControlLayersOption
-from rna_prop_ui import rna_idprop_ui_prop_get
+from ...utils.mechanism import make_property
 from ..limbs.limb_utils import get_bone_name
 
 script = """
@@ -935,16 +935,11 @@ class Rig:
 
         for prop in props:
             if prop == 'neck_follow':
-                torso[prop] = 0.5
+                defval = 0.5
             else:
-                torso[prop] = 0.0
+                defval = 0.0
 
-            prop = rna_idprop_ui_prop_get( torso, prop, create=True )
-            prop["min"]         = 0.0
-            prop["max"]         = 1.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = prop
+            make_property(torso, prop, defval)
 
         # driving the follow rotation switches for neck and head
         for bone, prop, in zip( owners, props ):

--- a/rigs/faces/super_face.py
+++ b/rigs/faces/super_face.py
@@ -4,7 +4,7 @@ from   ...utils       import copy_bone, flip_bone
 from   ...utils       import org, strip_org, make_deformer_name, connected_children_names, make_mechanism_name
 from   ...utils       import create_circle_widget, create_sphere_widget, create_widget, create_cube_widget
 from   ...utils       import MetarigError
-from   rna_prop_ui    import rna_idprop_ui_prop_get
+from   ...utils.mechanism import make_property
 from   ..widgets import create_face_widget, create_eye_widget, create_eyes_widget, create_ear_widget, create_jaw_widget, create_teeth_widget
 
 
@@ -933,16 +933,11 @@ class Rig:
 
         for bone, prop_name in zip( [ jaw_ctrl, eyes_ctrl ], [ jaw_prop, eyes_prop ] ):
             if bone == jaw_ctrl:
-                pb[ bone ][ prop_name ] = 0.0
+                defval = 0.0
             else:
-                pb[ bone ][ prop_name ] = 1.0
+                defval = 1.0
 
-            prop = rna_idprop_ui_prop_get( pb[ bone ], prop_name )
-            prop["min"]         = 0.0
-            prop["max"]         = 1.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = prop_name
+            make_property(pb[ bone ], prop_name, defval)
 
         # Jaw drivers
         mch_jaws = all_bones['mch']['jaw'][1:-1]

--- a/rigs/limbs/arm.py
+++ b/rigs/limbs/arm.py
@@ -11,7 +11,7 @@ from ...utils       import create_limb_widget, connected_children_names
 from ...utils       import align_bone_x_axis, align_bone_z_axis
 from ...rig_ui_template import UTILITIES_RIG_ARM, REGISTER_RIG_ARM
 from ...utils       import ControlLayersOption
-from rna_prop_ui import rna_idprop_ui_prop_get
+from ...utils.mechanism import make_property
 from ..widgets import create_ikarrow_widget
 from math import trunc, pi
 
@@ -121,14 +121,7 @@ class Rig:
 
         # pb[ mch ][ name ] = 0.0
         # prop = rna_idprop_ui_prop_get( pb[ mch ], name, create = True )
-        pb[main_parent][name] = 0.0
-        prop = rna_idprop_ui_prop_get(pb[main_parent], name, create=True)
-
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = name
+        make_property(pb[main_parent], name, 0.0)
 
         drv = pb[mch].constraints[0].driver_add("influence").driver
 
@@ -332,17 +325,11 @@ class Rig:
             name = 'rubber_tweak'
 
             if i == trunc( len( tweaks[1:-1] ) / 2 ):
-                pb[t][name] = 0.0
+                defval = 0.0
             else:
-                pb[t][name] = 1.0
+                defval = 1.0
 
-            prop = rna_idprop_ui_prop_get( pb[t], name, create=True )
-
-            prop["min"]         = 0.0
-            prop["max"]         = 2.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = name
+            make_property(pb[t], name, defval, max=2.0, soft_max=1.0)
 
         for j,d in enumerate(def_bones[:-1]):
             drvs = {}
@@ -557,13 +544,7 @@ class Rig:
         pb_parent = pb[parent]
 
         # Create ik/fk switch property
-        pb_parent['IK_FK'] = 0.0
-        prop = rna_idprop_ui_prop_get(pb_parent, 'IK_FK', create=True)
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = 'IK/FK Switch'
+        prop = make_property(pb_parent, 'IK_FK', 0.0, description='IK/FK Switch')
 
         # Constrain org to IK and FK bones
         iks = [ik['ctrl']['limb']]
@@ -713,13 +694,7 @@ class Rig:
         for b in bones['tweak']['ctrl']:
             pb[b].rotation_mode = 'ZXY'
 
-        pb_parent['IK_Stretch'] = 1.0
-        prop = rna_idprop_ui_prop_get(pb_parent, 'IK_Stretch', create=True)
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = 'IK Stretch'
+        prop = make_property(pb_parent, 'IK_Stretch', 1.0, description='IK Stretch')
 
         # Add driver to limit scale constraint influence
         b = bones['ik']['mch_str']
@@ -767,11 +742,7 @@ class Rig:
         for prop in props:
 
             if prop == 'pole_vector':
-                owner[prop] = False
-                pole_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                pole_prop["min"] = False
-                pole_prop["max"] = True
-                pole_prop["description"] = prop
+                make_property(owner, prop, False)
                 mch_ik = pb[bones['ik']['mch_ik']]
 
                 # ik target hide driver
@@ -855,11 +826,7 @@ class Rig:
 
             elif prop == 'IK_follow':
 
-                owner[prop] = True
-                rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                rna_prop["min"] = False
-                rna_prop["max"] = True
-                rna_prop["description"] = prop
+                make_property(owner, prop, True)
 
                 drv = ctrl.constraints[0].driver_add("mute").driver
                 drv.type = 'AVERAGE'
@@ -933,13 +900,7 @@ class Rig:
 
             elif prop == 'root/parent':
                 if len(ctrl.constraints) > 1:
-                    owner[prop] = 0.0
-                    rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                    rna_prop["min"] = 0.0
-                    rna_prop["max"] = 1.0
-                    rna_prop["soft_min"] = 0.0
-                    rna_prop["soft_max"] = 1.0
-                    rna_prop["description"] = prop
+                    make_property(owner, prop, 0.0)
 
                     drv = ctrl.constraints[1].driver_add("influence").driver
                     drv.type = 'AVERAGE'
@@ -953,13 +914,7 @@ class Rig:
 
             elif prop == 'pole_follow':
                 if len(ctrl_pole.constraints) > 1:
-                    owner[prop] = 0.0
-                    rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                    rna_prop["min"] = 0.0
-                    rna_prop["max"] = 1.0
-                    rna_prop["soft_min"] = 0.0
-                    rna_prop["soft_max"] = 1.0
-                    rna_prop["description"] = prop
+                    make_property(owner, prop, 0.0)
 
                     drv = ctrl_pole.constraints[1].driver_add("influence").driver
                     drv.type = 'AVERAGE'

--- a/rigs/limbs/leg.py
+++ b/rigs/limbs/leg.py
@@ -13,6 +13,7 @@ from ...utils import align_bone_y_axis, align_bone_x_axis, align_bone_z_axis
 from ...rig_ui_template import UTILITIES_RIG_LEG, REGISTER_RIG_LEG
 from ...utils import ControlLayersOption
 from rna_prop_ui import rna_idprop_ui_prop_get
+from ...utils.mechanism import make_property
 from ..widgets import create_ikarrow_widget
 from math import trunc, pi
 
@@ -148,14 +149,7 @@ class Rig:
 
         # pb[ mch ][ name ] = 0.0
         # prop = rna_idprop_ui_prop_get( pb[ mch ], name, create = True )
-        pb[main_parent][name] = 0.0
-        prop = rna_idprop_ui_prop_get(pb[main_parent], name, create=True)
-
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = name
+        make_property(pb[main_parent], name, 0.0)
 
         drv = pb[mch].constraints[0].driver_add("influence").driver
 
@@ -359,17 +353,11 @@ class Rig:
             name = 'rubber_tweak'
 
             if i == trunc( len( tweaks[1:-1] ) / 2 ):
-                pb[t][name] = 0.0
+                defval = 0.0
             else:
-                pb[t][name] = 1.0
+                defval = 1.0
 
-            prop = rna_idprop_ui_prop_get( pb[t], name, create=True )
-
-            prop["min"]         = 0.0
-            prop["max"]         = 2.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = name
+            make_property(pb[t], name, defval, max=2.0, soft_max=1.0)
 
         for j,d in enumerate(def_bones[:-1]):
             drvs = {}
@@ -584,13 +572,7 @@ class Rig:
         pb_parent = pb[parent]
 
         # Create ik/fk switch property
-        pb_parent['IK_FK'] = 0.0
-        prop = rna_idprop_ui_prop_get(pb_parent, 'IK_FK', create=True)
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = 'IK/FK Switch'
+        prop = make_property(pb_parent, 'IK_FK', 0.0, description='IK/FK Switch')
 
         # Constrain org to IK and FK bones
         iks = [ik['ctrl']['limb']]
@@ -955,13 +937,7 @@ class Rig:
         pb_parent.lock_rotation = True, True, True
         pb_parent.lock_scale = True, True, True
 
-        pb_parent['IK_Stretch'] = 1.0
-        prop = rna_idprop_ui_prop_get(pb_parent, 'IK_Stretch', create=True)
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = 'IK Stretch'
+        prop = make_property(pb_parent, 'IK_Stretch', 1.0, description='IK Stretch')
 
         # Add driver to limit scale constraint influence
         b = bones['ik']['mch_str']
@@ -1087,11 +1063,7 @@ class Rig:
         for prop in props:
 
             if prop == 'pole_vector':
-                owner[prop] = False
-                pole_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                pole_prop["min"] = False
-                pole_prop["max"] = True
-                pole_prop["description"] = prop
+                make_property(owner, prop, False)
                 mch_ik = pb[bones['ik']['mch_ik']]
 
                 # ik target hide driver
@@ -1175,11 +1147,7 @@ class Rig:
 
             elif prop == 'IK_follow':
 
-                owner[prop] = True
-                rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                rna_prop["min"] = False
-                rna_prop["max"] = True
-                rna_prop["description"] = prop
+                make_property(owner, prop, True)
 
                 drv = ctrl.constraints[0].driver_add("mute").driver
                 drv.type = 'AVERAGE'
@@ -1253,13 +1221,7 @@ class Rig:
 
             elif prop == 'root/parent':
                 if len(ctrl.constraints) > 1:
-                    owner[prop] = 0.0
-                    rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                    rna_prop["min"] = 0.0
-                    rna_prop["max"] = 1.0
-                    rna_prop["soft_min"] = 0.0
-                    rna_prop["soft_max"] = 1.0
-                    rna_prop["description"] = prop
+                    make_property(owner, prop, 0.0)
 
                     drv = ctrl.constraints[1].driver_add("influence").driver
                     drv.type = 'AVERAGE'
@@ -1273,13 +1235,7 @@ class Rig:
 
             elif prop == 'pole_follow':
                 if len(ctrl_pole.constraints) > 1:
-                    owner[prop] = 0.0
-                    rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                    rna_prop["min"] = 0.0
-                    rna_prop["max"] = 1.0
-                    rna_prop["soft_min"] = 0.0
-                    rna_prop["soft_max"] = 1.0
-                    rna_prop["description"] = prop
+                    make_property(owner, prop, 0.0)
 
                     drv = ctrl_pole.constraints[1].driver_add("influence").driver
                     drv.type = 'AVERAGE'

--- a/rigs/limbs/paw.py
+++ b/rigs/limbs/paw.py
@@ -11,6 +11,7 @@ from ...utils import align_bone_x_axis, align_bone_z_axis
 from ...rig_ui_template import UTILITIES_RIG_LEG, REGISTER_RIG_LEG
 from ...utils import ControlLayersOption
 from rna_prop_ui import rna_idprop_ui_prop_get
+from ...utils.mechanism import make_property
 from ..widgets import create_ikarrow_widget, create_gear_widget
 from ..widgets import create_foot_widget, create_ballsocket_widget
 from math import trunc, pi
@@ -134,14 +135,7 @@ class Rig:
 
         # pb[ mch ][ name ] = 0.0
         # prop = rna_idprop_ui_prop_get( pb[ mch ], name, create = True )
-        pb[main_parent][name] = 0.0
-        prop = rna_idprop_ui_prop_get(pb[main_parent], name, create=True)
-
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = name
+        make_property(pb[main_parent], name, 0.0)
 
         drv = pb[mch].constraints[0].driver_add("influence").driver
 
@@ -350,17 +344,11 @@ class Rig:
             name = 'rubber_tweak'
 
             if not (i+1) % self.segments:
-                pb[t][name] = 0.0
+                defvalue = 0.0
             else:
-                pb[t][name] = 1.0
+                defvalue = 1.0
 
-            prop = rna_idprop_ui_prop_get( pb[t], name, create=True )
-
-            prop["min"]         = 0.0
-            prop["max"]         = 2.0
-            prop["soft_min"]    = 0.0
-            prop["soft_max"]    = 1.0
-            prop["description"] = name
+            make_property(pb[t], name, defvalue, max=2.0, soft_max=1.0)
 
         for j,d in enumerate(def_bones[:-1]):
             drvs = {}
@@ -578,13 +566,7 @@ class Rig:
         pb_parent = pb[parent]
 
         # Create ik/fk switch property
-        pb_parent['IK_FK'] = 0.0
-        prop = rna_idprop_ui_prop_get(pb_parent, 'IK_FK', create=True)
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = 'IK/FK Switch'
+        prop = make_property(pb_parent, 'IK_FK', 0.0, description='IK/FK Switch')
 
         # Constrain org to IK and FK bones
         iks = [ik['ctrl']['limb']]
@@ -784,13 +766,7 @@ class Rig:
         pb_parent.lock_rotation = True, True, True
         pb_parent.lock_scale = True, True, True
 
-        pb_parent['IK_Stretch'] = 1.0
-        prop = rna_idprop_ui_prop_get(pb_parent, 'IK_Stretch', create=True)
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = 'IK Stretch'
+        prop = make_property(pb_parent, 'IK_Stretch', 1.0, description='IK Stretch')
 
         # Add driver to limit scale constraint influence
         b = bones['ik']['mch_str']
@@ -914,11 +890,7 @@ class Rig:
         for prop in props:
 
             if prop == 'pole_vector':
-                owner[prop] = False
-                pole_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                pole_prop["min"] = False
-                pole_prop["max"] = True
-                pole_prop["description"] = prop
+                make_property(owner, prop, False)
                 mch_ik = pb[bones['ik']['mch_ik']]
 
                 # ik target hide driver
@@ -1002,11 +974,7 @@ class Rig:
 
             elif prop == 'IK_follow':
 
-                owner[prop] = True
-                rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                rna_prop["min"] = False
-                rna_prop["max"] = True
-                rna_prop["description"] = prop
+                make_property(owner, prop, True)
 
                 drv = ctrl.constraints[0].driver_add("mute").driver
                 drv.type = 'AVERAGE'
@@ -1080,13 +1048,7 @@ class Rig:
 
             elif prop == 'root/parent':
                 if len(ctrl.constraints) > 1:
-                    owner[prop] = 0.0
-                    rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                    rna_prop["min"] = 0.0
-                    rna_prop["max"] = 1.0
-                    rna_prop["soft_min"] = 0.0
-                    rna_prop["soft_max"] = 1.0
-                    rna_prop["description"] = prop
+                    make_property(owner, prop, 0.0)
 
                     drv = ctrl.constraints[1].driver_add("influence").driver
                     drv.type = 'AVERAGE'
@@ -1100,13 +1062,7 @@ class Rig:
 
             elif prop == 'pole_follow':
                 if len(ctrl_pole.constraints) > 1:
-                    owner[prop] = 0.0
-                    rna_prop = rna_idprop_ui_prop_get(owner, prop, create=True)
-                    rna_prop["min"] = 0.0
-                    rna_prop["max"] = 1.0
-                    rna_prop["soft_min"] = 0.0
-                    rna_prop["soft_max"] = 1.0
-                    rna_prop["description"] = prop
+                    make_property(owner, prop, 0.0)
 
                     drv = ctrl_pole.constraints[1].driver_add("influence").driver
                     drv.type = 'AVERAGE'

--- a/rigs/limbs/super_finger.py
+++ b/rigs/limbs/super_finger.py
@@ -3,7 +3,7 @@ from ...utils import copy_bone, flip_bone
 from ...utils import strip_org, make_deformer_name, connected_children_names, make_mechanism_name
 from ...utils import create_circle_widget, create_widget
 from ...utils import MetarigError, align_bone_x_axis
-from rna_prop_ui import rna_idprop_ui_prop_get
+from ...utils.mechanism import make_property
 
 script = """
 controls    = [%s]
@@ -173,13 +173,7 @@ class Rig:
         pb[tip_name].lock_rotation = True, True, True
         pb[tip_name].lock_rotation_w = True
 
-        pb_master['finger_curve'] = 0.0
-        prop = rna_idprop_ui_prop_get(pb_master, 'finger_curve')
-        prop["min"] = 0.0
-        prop["max"] = 1.0
-        prop["soft_min"] = 0.0
-        prop["soft_max"] = 1.0
-        prop["description"] = "Rubber hose finger cartoon effect"
+        make_property(pb_master, 'finger_curve', 0.0, description="Rubber hose finger cartoon effect")
 
         # Pose settings
         for org, ctrl, deform, mch, mch_drv in zip(self.org_bones, ctrl_chain, def_chain, mch_chain, mch_drv_chain):

--- a/rigs/spines/super_spine.py
+++ b/rigs/spines/super_spine.py
@@ -6,7 +6,7 @@ from ...utils import create_circle_widget, create_sphere_widget, create_neck_ben
 from ..widgets import create_ballsocket_widget
 from ...utils import MetarigError, make_mechanism_name, create_cube_widget
 from ...utils import ControlLayersOption
-from rna_prop_ui import rna_idprop_ui_prop_get
+from ...utils.mechanism import make_property
 
 script = """
 controls = [%s]
@@ -766,16 +766,11 @@ class Rig:
 
         for prop in props:
             if prop == 'neck_follow':
-                torso[prop] = 0.5
+                defval = 0.5
             else:
-                torso[prop] = 0.0
+                defval = 0.0
 
-            prop = rna_idprop_ui_prop_get(torso, prop, create=True)
-            prop["min"] = 0.0
-            prop["max"] = 1.0
-            prop["soft_min"] = 0.0
-            prop["soft_max"] = 1.0
-            prop["description"] = prop
+            make_property(torso, prop, defval)
 
         # driving the follow rotation switches for neck and head
         for bone, prop, in zip(owners, props):

--- a/ui.py
+++ b/ui.py
@@ -177,11 +177,15 @@ class DATA_PT_rigify_buttons(bpy.types.Panel):
             # Build types list
             build_type_list(context, id_store.rigify_types)
 
+            if id_store.rigify_active_type > len(id_store.rigify_types):
+                id_store.rigify_active_type = 0
+
             # Rig type list
             if len(feature_sets.feature_set_items(context.scene, context)) > 2:
                 row = layout.row()
                 row.prop(context.object.data, "active_feature_set")
             row = layout.row()
+            row.template_list("UI_UL_list", "rigify_types", id_store, "rigify_types", id_store, 'rigify_active_type')
 
             props = layout.operator("armature.metarig_sample_add", text="Add sample")
             props.metarig_type = id_store.rigify_types[id_store.rigify_active_type].name

--- a/utils/mechanism.py
+++ b/utils/mechanism.py
@@ -78,7 +78,7 @@ def make_constraint(
 # Custom property creation utilities
 #=============================================
 
-def make_property(owner, name, default=0.0, min=0.0, max=1.0, soft_min=None, soft_max=None):
+def make_property(owner, name, default=0.0, min=0.0, max=1.0, soft_min=None, soft_max=None, description=None):
     """
     Creates and initializes a custom property of owner.
 
@@ -91,6 +91,8 @@ def make_property(owner, name, default=0.0, min=0.0, max=1.0, soft_min=None, sof
     prop["soft_min"] = soft_min if soft_min is not None else min
     prop["max"] = max
     prop["soft_max"] = soft_max if soft_max is not None else max
+    if description:
+        prop["description"] = description
 
     return prop
 
@@ -102,7 +104,7 @@ def _init_driver_target(drv_target, var_info, target_id):
     """Initialize a driver variable target from a specification."""
 
     # Parse the simple list format for the common case.
-    if isinstance(var_info, list):
+    if isinstance(var_info, tuple):
         # [ (target_id,) subtarget, ...path ]
 
         # If target_id is supplied as parameter, allow omitting it
@@ -144,7 +146,7 @@ def _add_driver_variable(drv, var_name, var_info, target_id):
     var.name = var_name
 
     # Parse the simple list format for the common case.
-    if isinstance(var_info, list):
+    if isinstance(var_info, tuple):
         # [ (target_id,) subtarget, ...path ]
         var.type = "SINGLE_PROP"
 
@@ -182,13 +184,13 @@ def make_driver(owner, prop, index=-1, type='SUM', expression=None, variables={}
 
         Variable specifications are constructed as nested dictionaries and lists that
         follow the property structure of the original Blender objects, but the most
-        common case can be abbreviated as a simple list.
+        common case can be abbreviated as a simple tuple.
 
         The following specifications are equivalent:
 
-          [ target, subtarget, '.foo', 'bar' ]
+          ( target, subtarget, '.foo', 'bar' )
 
-          { 'type': 'SINGLE_PROP', 'targets':[[ target, subtarget, '.foo', 'bar' ]] }
+          { 'type': 'SINGLE_PROP', 'targets':[( target, subtarget, '.foo', 'bar' )] }
 
           { 'type': 'SINGLE_PROP',
             'targets':[{ 'id': target, 'data_path': subtarget.path_from_id() + '.foo["bar"]' }] }
@@ -197,13 +199,13 @@ def make_driver(owner, prop, index=-1, type='SUM', expression=None, variables={}
 
         It is possible to specify path directly as a simple string without following items:
 
-          [ target, 'path' ]
+          ( target, 'path' )
 
           { 'type': 'SINGLE_PROP', 'targets':[{ 'id': target, 'data_path': 'path' }] }
 
         If the target_id parameter is not None, it is possible to omit target:
 
-          [ subtarget, '.foo', 'bar' ]
+          ( subtarget, '.foo', 'bar' )
 
           { 'type': 'SINGLE_PROP',
             'targets':[{ 'id': target_id, 'data_path': subtarget.path_from_id() + '.foo["bar"]' }] }
@@ -241,7 +243,7 @@ def make_driver(owner, prop, index=-1, type='SUM', expression=None, variables={}
 # Utility mixin
 #=============================================
 
-class MechanismUtilityMixin:
+class MechanismUtilityMixin(object):
     """
     Provides methods for more convenient creation of constraints, properties
     and drivers within an armature (by implicitly providing context).

--- a/utils/mechanism.py
+++ b/utils/mechanism.py
@@ -78,21 +78,35 @@ def make_constraint(
 # Custom property creation utilities
 #=============================================
 
-def make_property(owner, name, default=0.0, min=0.0, max=1.0, soft_min=None, soft_max=None, description=None):
+def make_property(owner, name, default, min=0.0, max=1.0, soft_min=None, soft_max=None, description=None, overridable=True):
     """
     Creates and initializes a custom property of owner.
 
     The soft_min and soft_max parameters default to min and max.
+    Description defaults to the property name.
     """
     owner[name] = default
 
     prop = rna_idprop_ui_prop_get(owner, name, create=True)
-    prop["min"] = min
-    prop["soft_min"] = soft_min if soft_min is not None else min
-    prop["max"] = max
-    prop["soft_max"] = soft_max if soft_max is not None else max
-    if description:
-        prop["description"] = description
+
+    if soft_min is None:
+        soft_min = min
+    if soft_max is None:
+        soft_max = max
+
+    proptype = type(default)
+
+    if proptype in {int, float}:
+        prop["min"] = proptype(min)
+        prop["soft_min"] = proptype(soft_min)
+        prop["max"] = proptype(max)
+        prop["soft_max"] = proptype(soft_max)
+
+    elif proptype is bool:
+        prop["min"] = prop["soft_min"] = False
+        prop["max"] = prop["soft_max"] = True
+
+    prop["description"] = description or name
 
     return prop
 
@@ -255,9 +269,9 @@ class MechanismUtilityMixin(object):
         assert(self.obj.mode == 'OBJECT')
         return make_constraint(self.obj.pose.bones[bone], type, self.obj, subtarget, **args)
 
-    def make_property(self, bone, name, **args):
+    def make_property(self, bone, name, default, **args):
         assert(self.obj.mode == 'OBJECT')
-        return make_property(self.obj.pose.bones[bone], name, **args)
+        return make_property(self.obj.pose.bones[bone], name, default, **args)
 
     def make_driver(self, owner, prop, **args):
         assert(self.obj.mode == 'OBJECT')


### PR DESCRIPTION
This includes changes that have already been committed to the upstream 2.8 addons repository.

- Fix: RigifyParameters is cleared when toggling legacy mode to shut up warnings in the console.
- Fix: Bend Hint wording mismatch is fixed to shut up warnings.
- Updates the Feature Set patches with tweaks done before committing to upstream, including a fix for broken "Add Sample" UI.
- Rigs are modified to use the new make_property utility function (back-portable part of a 2.8 API compatibility update commit). Custom properties created without the use of that function will be defective in 2.8.